### PR TITLE
Remove unnecessary widget

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "Editor for a tool that can explore 3D spaces.",
   "majorVersion": 0,
   "minorVersion": 4,
-  "patchVersion": 20,
+  "patchVersion": 21,
   "runnable": 0,
   "author": "Joubel, NDLA",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "h5p-editor-ndla-three-image",
-  "version": "0.4.19",
+  "version": "0.4.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "h5p-editor-ndla-three-image",
-      "version": "0.4.19",
+      "version": "0.4.21",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.22.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "h5p-editor-ndla-three-image",
-  "version": "0.4.19",
+  "version": "0.4.21",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/Main.scss
+++ b/src/components/Main.scss
@@ -23,4 +23,33 @@
   .scene-wrapper.no-scenes .scene-container {
     display: none;
   }
+
+  .h5p-editing-dialog .field-name-iconTypeTextBox .h5p-editor-radio-group-container {
+    .h5p-editor-radio-group-button {
+      font-family: "360-Image";
+
+      &.checked {
+        background-color: #b0b0b0;
+        border-radius: 2px;
+      }
+
+      &:hover {
+        background-color: #d8d8d8;
+      }
+
+      &.text-icon::before {
+        content: "\e91f"
+      }
+      &.info-icon::before {
+        content: "\e91a"
+      }
+    }
+
+    &.horizontal {
+      .h5p-editor-radio-group-button {
+        display: inline-block;
+        padding: 0.2rem 0.5rem;
+      }
+    }
+  }
 }


### PR DESCRIPTION
When merged in, will provide the CSS to style the radio group editor widget for subcontent forms, so https://github.com/NDLANO/h5p-ndla-virtual-tour/pull/136 can be used.