### PR TITLE
refactor: rename runnable repo to escape room

### DIFF
--- a/library.json
+++ b/library.json
@@ -65,7 +65,7 @@
       "minorVersion": 5
     },
     {
-      "machineName": "H5P.NDLAThreeImage",
+      "machineName": "H5P.EscapeRoom",
       "majorVersion": 0,
       "minorVersion": 5
     },

--- a/src/scripts/h5phelpers/h5pComponents.js
+++ b/src/scripts/h5phelpers/h5pComponents.js
@@ -8,7 +8,7 @@
 export const initializeThreeSixtyPreview = (container, params, l10n) => {
   const library = Object.keys(H5PEditor.libraryLoaded)
     .filter((library) => {
-      return library.split(' ')[0] === 'H5P.NDLAThreeImage';
+      return library.split(' ')[0] === 'H5P.EscapeRoom';
     })[0];
 
   return H5P.newRunnable(


### PR DESCRIPTION
Renames `H5P.NDLAThreeImage` dependency to `H5P.EscapeRoom`.
Need to change updated major/minor version if needed as well.